### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,14 @@ jobs:
         with:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ steps.node_version.outputs.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ steps.node_version.outputs.NODE_VERSION }}
+
       - run: npm ci
         name: Install
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 'on':
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+name: Deploy
+
+'on':
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+
+      - run: npm ci
+        name: Install
+
+      - run: npm run build
+        name: Build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,14 @@ jobs:
         with:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ steps.node_version.outputs.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ steps.node_version.outputs.NODE_VERSION }}
+
       - run: npm ci
         name: Install
 


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow that deploys the built Gatsby site to GitHub Pages.

One thing that I'm currently figuring out is how to include the tutorials with the site. There are two options:

1. Have the tutorials repo deploy into a subdirectory of this repo's `gh-pages`.
2. Have the tutorials build create an artifact that's made available to the learn-astropy repo. Via a `repository_dispatch` webhook trigger, the tutorials repo can trigger a deployment of `learn-astropy` that includes the built tutorials content.

The first option might be easier but has the downside that the deployments to github pages can't delete "old" files so that e.g. a tutorials build doesn't clobber the learn-astropy homepage build. In that sense, the second option is technically more correct.