### PR TITLE
Add /learn-astropy path prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: `/learn-astropy`, // FIXME remove for deployment to learn.astropy.org/
   siteMetadata: {
     title: 'Learn Astropy',
     description:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "lint": "eslint .",


### PR DESCRIPTION
This temporarily enables us to deploy from GitHub Pages to astropy.org/learn-astropy.

Once we're ready to change the DNS to deploy to learn.astropy.org, we need to remove this `pathPrefix` config.