### PR TITLE
Configure for production

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  pathPrefix: `/learn-astropy`, // FIXME remove for deployment to learn.astropy.org/
   siteMetadata: {
     title: 'Learn Astropy',
     description:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
-    "build": "gatsby build --prefix-paths",
+    "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "lint": "eslint .",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,11 +30,11 @@ export default function IndexPage({ location }) {
         </p>
       </PageCover>
 
-      <InstantSearch searchClient={searchClient} indexName="algolia_test">
+      <InstantSearch searchClient={searchClient} indexName="prod_learn_astropy">
         <Configure distinct facetingAfterDistinct />
         <PrioritySort
-          priorityRefinement="algolia_test_priority"
-          relevanceRefinement="algolia_test"
+          priorityRefinement="prod_learn_astropy_priority"
+          relevanceRefinement="prod_learn_astropy"
         />
         <SearchLayout>
           <div className="search-box-area">

--- a/src/searchClient.js
+++ b/src/searchClient.js
@@ -2,8 +2,8 @@ import algoliasearch from 'algoliasearch/lite';
 
 // This is the Search-only API key
 const searchClient = algoliasearch(
-  'KSDFJKHCO2',
-  'fadf7c74af324735d9e45d68481531ab'
+  'H6MWLDHTG5',
+  '45fc58ab091520ba879eb8952b422c4e'
 );
 
 export default searchClient;

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+learn.astropy.org


### PR DESCRIPTION
This updates and configures the app for production deployment:

- revert the path prefix build setting since the site will be deployed at the root path of learn.astropy.org.
- Point to a new Algolia app/index that will be populated with data pointing to the new tutorials deployment at learn.astropy.org/tutorials

*This PR should be merged at the same time the DNS is updated.*