### PR TITLE
Automate Algolia indexing for tutorials in deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -90,3 +90,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+
+      - name: Index tutorials
+        with:
+          - ALGOLIA_ID: ${{ ALGOLIA_ID }}
+          - ALGOLIA_KEY: ${{ ALGOLIA_KEY }}
+          - ALGOLIA_INDEX: ${{ALGOLIA_INDEX }}
+        run: |
+          astropylibrarian index tutorial-site \
+            public/tutorials \
+            https://learn.astropy.org/tutorials

--- a/.github/workflows/testdeploy.yaml
+++ b/.github/workflows/testdeploy.yaml
@@ -20,6 +20,10 @@ jobs:
           python -m pip install -U pip
           python -m pip install -r deployment/requirements.txt
 
+      - name: Check Astropy Librarian installation
+        run: |
+          astropylibrarian --help
+
       - name: Download latest tutorials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,2 +1,3 @@
 requests
 uritemplate
+git+https://github.com/astropy/learn-astropy-librarian.git#egg=astropy-librarian


### PR DESCRIPTION
This PR adds a step to the deployment workflow (deploy.yaml) that runs `astropylibrarian index tutorial-site` (https://github.com/astropy/learn-astropy-librarian/pull/22) upon completion of the deployment. This command runs with the local astropy-tutorials build artifact so there aren't any concerns about race conditions between the indexing step and GitHub Pages making the latest deployment of the tutorials available through its CDN.

One thing I need to add in the future is a further step to check for deleted or renamed tutorials, and then drop those stale records from Algolia. The logic for this needs to be added to Learn Astropy Librarian first, though.

Lastly, I've added the Algolia secrets needed for this workflow via the repository secrets settings.