### PR TITLE
Fix typos in indexing step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -92,10 +92,10 @@ jobs:
           publish_dir: ./public
 
       - name: Index tutorials
-        with:
-          - ALGOLIA_ID: ${{ ALGOLIA_ID }}
-          - ALGOLIA_KEY: ${{ ALGOLIA_KEY }}
-          - ALGOLIA_INDEX: ${{ALGOLIA_INDEX }}
+        env:
+          ALGOLIA_ID: ${{ secrets.ALGOLIA_ID }}
+          ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
+          ALGOLIA_INDEX: ${{ secrets.ALGOLIA_INDEX }}
         run: |
           astropylibrarian index tutorial-site \
             public/tutorials \


### PR DESCRIPTION
This fixes typo in deploy.yaml for automatically running astropylibrarian (I'd never tested it since it needs a merge to main).