### PR TITLE
Resolve build and deploy actions failures

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/testdeploy.yaml
+++ b/.github/workflows/testdeploy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/testdeploy.yaml
+++ b/.github/workflows/testdeploy.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install pip==23.3.2
+          python -m pip install -U pip
           python -m pip install -r deployment/requirements.txt
 
       - name: Check Astropy Librarian installation

--- a/.github/workflows/testdeploy.yaml
+++ b/.github/workflows/testdeploy.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip<24.0
           python -m pip install -r deployment/requirements.txt
 
       - name: Check Astropy Librarian installation

--- a/.github/workflows/testdeploy.yaml
+++ b/.github/workflows/testdeploy.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip<24.0
+          python -m pip install pip==23.3.2
           python -m pip install -r deployment/requirements.txt
 
       - name: Check Astropy Librarian installation

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 .cache
+.github
 package.json
 package-lock.json
 public


### PR DESCRIPTION
The build and deploy CI checks are currently failing on `main` due to multiple problems. This resolves those. Changes:

- exclude `.github` from `prettier` formatting check
- update python versions in CI